### PR TITLE
Added a new options "type" named "select_with_values"

### DIFF
--- a/options-interface.php
+++ b/options-interface.php
@@ -216,15 +216,15 @@ function optionsframework_fields() {
 			$output .= '<select class="of-input" name="'.$option_name.'['.$value['id'].']" id="'. $value['id'] .'">';
 			$select_value = $settings[($value['id'])];
 			
-			foreach ($value['options'] as $option_value => $option) {
+			foreach ($value['options'] as $key => $option ) {
 				$selected = '';
 				 if($select_value != '') {
-					 if ( $select_value == $option_value) { $selected = ' selected="selected"';} 
+					 if ( $select_value == $key) { $selected = ' selected="selected"';} 
 			     } else {
 					 if ( isset($value['std']) )
-						 if ($value['std'] == $option_value) { $selected = ' selected="selected"'; }
+						 if ($value['std'] == $key) { $selected = ' selected="selected"'; }
 				 }
-				 $output .= '<option'. $selected .' value="' . $option_value . '">';
+				 $output .= '<option'. $selected .' value="' . $key . '">';
 				 $output .= $option;
 				 $output .= '</option>';
 			 } 


### PR DESCRIPTION
I added an option type that creates a select field that uses the options array keys in the database but still displays the array's value for users (such as with the radio type.) This is useful for instance to show users a list of categories to select from while storing the category slug for programmatic use. I made this clone of the "select" type for my own uses but it might make more sense to have a new option such as "use_key_as_value" that can be applied to "radio" as well as "select" fields.
