### PR TITLE
Allow for multiple paragraphs on info options

### DIFF
--- a/options-interface.php
+++ b/options-interface.php
@@ -273,7 +273,7 @@ function optionsframework_fields() {
 				$output .= '<h3 class="heading">' . esc_html( $value['name'] ) . '</h3>' . "\n";
 			}
 			if ( $value['desc'] ) {
-				$output .= '<p>'. wp_kses( $value['desc'], $allowedtags) . '</p>' . "\n";
+				$output .= wpautop( wp_kses( $value['desc'], $allowedtags) ) . "\n";
 			}
 			$output .= '<div class="clear"></div></div>' . "\n";
 		break;                       


### PR DESCRIPTION
Allow for multiple paragraphs on Info options by using wpautop() instead of wrapping content in <code>p</code> tags by default.
