### PR TITLE
Added back in wpautop() for info description.

### DIFF
--- a/options-interface.php
+++ b/options-interface.php
@@ -277,7 +277,7 @@ function optionsframework_fields() {
 				$output .= '<h4 class="heading">' . esc_html( $value['name'] ) . '</h4>' . "\n";
 			}
 			if ( $value['desc'] ) {
-				$output .= apply_filters('of_sanitize_info', $value['desc'] ) . "\n";
+				$output .= wpautop( apply_filters( 'of_sanitize_info', $value['desc'] ) ) . "\n";
 			}
 			$output .= '<div class="clear"></div></div>' . "\n";
 		break;                       


### PR DESCRIPTION
Added wpautop() to the Info options description. This allows for the content, sanitized or not, to be wrapped in a <p> tags.
