### PR TITLE
Small CSS Change

### DIFF
--- a/css/admin-style.css
+++ b/css/admin-style.css
@@ -10,6 +10,7 @@
 	position:relative;
 	z-index: 0;
 	max-width:780px;
+	background: #fff;
 }
 #optionsframework p {
 	margin-bottom:0;


### PR DESCRIPTION
This is REALLY small and minor but thought I would add anyway. Added a white background color to the #optionsframework ID. In WP 3.2, the .postbox class (which is on the same div as #optionsframework) has a background color of #f5f5f5. In some cases, if an author applies some basic styling or jQuery improvements to the OF plugin, the light grey background shows. Again, very minor, but possibly attractive :)

FYI - I'm not 100% sure I'm doing this right when creating pull requests to submit update ideas... It's the only thing I've figured out on github at this point :) #needtolearn
