### PR TITLE
Load all theme options using https when applicable

### DIFF
--- a/options-medialibrary-uploader.php
+++ b/options-medialibrary-uploader.php
@@ -48,10 +48,10 @@ if ( ! function_exists( 'optionsframework_mlu_css' ) ) {
 	function optionsframework_mlu_css () {
 	
 		$_html = '';
-		$_html .= '<link rel="stylesheet" href="' . get_option('siteurl') . '/' . WPINC . '/js/thickbox/thickbox.css" type="text/css" media="screen" />' . "\n";
+		$_html .= '<link rel="stylesheet" href="' . site_url() . '/' . WPINC . '/js/thickbox/thickbox.css" type="text/css" media="screen" />' . "\n";
 		$_html .= '<script type="text/javascript">
-		var tb_pathToImage = "' . get_option('siteurl') . '/' . WPINC . '/js/thickbox/loadingAnimation.gif";
-	    var tb_closeImage = "' . get_option('siteurl') . '/' . WPINC . '/js/thickbox/tb-close.png";
+		var tb_pathToImage = "' . site_url() . '/' . WPINC . '/js/thickbox/loadingAnimation.gif";
+	    var tb_closeImage = "' . site_url() . '/' . WPINC . '/js/thickbox/tb-close.png";
 	    </script>' . "\n";
 	    
 	    echo $_html;


### PR DESCRIPTION
Load thickbox using site_url() instead of get_option('siteurl') to allow for https and to avoid cryptic security warnings in IE (see http://codex.wordpress.org/Function_Reference/site_url).
