### PR TITLE
Utilize the theme features API

### DIFF
--- a/options-framework.php
+++ b/options-framework.php
@@ -42,7 +42,7 @@ if ( !function_exists( 'add_action' ) ) {
 add_action('init', 'optionsframework_rolescheck' );
 
 function optionsframework_rolescheck () {
-	if ( current_user_can( 'edit_theme_options' ) && ( !is_multisite() || ( is_multisite() && current_theme_supports('options-framework') ) ) ) {
+	if ( current_user_can( 'edit_theme_options' ) && ( !is_multisite() || ( is_multisite() && current_theme_supports('options_framework') ) ) ) {
 		// If the user can edit theme options, let the fun begin!
 		add_action( 'admin_menu', 'optionsframework_add_page');
 		add_action( 'admin_init', 'optionsframework_init' );


### PR DESCRIPTION
I love the options framework, and I think it makes sense to use it as a plugin, if it's shared between multiple themes, but the problem is that it also is active on themes that don't support it.  Adding the "current_theme_supports" check makes it so that the options framework only loads if a theme adds the following during initialization:

``` php
add_theme_support('options-framework');
```

This way you can use the plugin with themes that support it, and not have it affect themes that don't.
