### PR TITLE
Do not display the title (h4.heading) if name is not specified. Allows a better reading for a group of options.

### DIFF
--- a/options-interface.php
+++ b/options-interface.php
@@ -52,7 +52,9 @@ function optionsframework_fields() {
 			}
 
 			$output .= '<div id="' . esc_attr( $id ) .'" class="' . esc_attr( $class ) . '">'."\n";
-			$output .= '<h4 class="heading">' . esc_html( $value['name'] ) . '</h4>' . "\n";
+			if ( isset( $value['name'] ) ) {
+				$output .= '<h4 class="heading">' . esc_html( $value['name'] ) . '</h4>' . "\n";
+			}
 			$output .= '<div class="option">' . "\n" . '<div class="controls">' . "\n";
 		 }
 		


### PR DESCRIPTION
Do not display h4.heading if $value['name'].
I think it's easier to read a group of options in admin interface without a separator before each option.

---

55: if ( isset( $value['name'] ) ) {
56:   $output .= '<h4 class="heading">' . esc_html( $value['name'] ) . '</h4>' . "\n";
## 57: }
