### PR TITLE
Make field types extensible.

### DIFF
--- a/options-interface.php
+++ b/options-interface.php
@@ -323,6 +323,10 @@ function optionsframework_fields() {
 			$output .= '<div class="group" id="' . esc_attr( $jquery_click_hook ) . '">';
 			$output .= '<h3>' . esc_html( $value['name'] ) . '</h3>' . "\n";
 			break;
+
+		// Extensible fields
+		default:
+			$output .= apply_filters( 'of_field_display_' . $value['type'], '', $val, $option_name, $value );
 		}
 
 		if ( ( $value['type'] != "heading" ) && ( $value['type'] != "info" ) ) {


### PR DESCRIPTION
Render a field with an of_field_display_FIELDTYPE filter

EG:

``` php
add_filter( 'of_field_display_mytype', 'sd_mytype_field', 10, 4 );
functon sd_mytype_field( $content, $value, $opt_name, $field ) {
    // generate your input
    return $content;
}
```
