### PR TITLE
Added optionsframework_after_validate hook

### DIFF
--- a/options-framework.php
+++ b/options-framework.php
@@ -409,6 +409,9 @@ function optionsframework_validate( $input ) {
 
 	add_settings_error( 'options-framework', 'save_options', __( 'Options saved.', 'optionsframework' ), 'updated fade' );
 	
+	// added to hook into after validation
+	do_action('optionsframework_after_validate');
+	
 	return $clean;
 
 }


### PR DESCRIPTION
Hi Devin,

I had a project that required me to tie in after the validation ran, so I added a hook for it. I was hoping that you'd merge it in. Thanks again for the great plugin!

Best,
Evan
