### PR TITLE
Added a hook to allow you to do custom validation of options during save

### DIFF
--- a/options-framework.php
+++ b/options-framework.php
@@ -407,6 +407,8 @@ function optionsframework_validate( $input ) {
 		}
 	}
 
+	if ( function_exists( 'optionsframework_on_validate' ) ) optionsframework_on_validate($clean);
+
 	add_settings_error( 'options-framework', 'save_options', __( 'Options saved.', 'optionsframework' ), 'updated fade' );
 	
 	return $clean;


### PR DESCRIPTION
For example, suppose I am implementing Facebook Connect in my theme and using Options Framework to store the App ID/Secret, this hook allows me to verify that the Facebook App ID/Secret entered in the options are correct, and if not, alert the user and prevent the Facebook API scripts from loading.

Demo code here: https://gist.github.com/4179688
