### PR TITLE
Modified style and script path to be flexible

### DIFF
--- a/includes/class-options-framework-admin.php
+++ b/includes/class-options-framework-admin.php
@@ -180,7 +180,7 @@ class Options_Framework_Admin {
 		if ( $this->options_screen != $hook )
 	        return;
 
-		wp_enqueue_style( 'optionsframework', plugin_dir_url( dirname(__FILE__) ) . 'css/optionsframework.css', array(),  Options_Framework::VERSION );
+		wp_enqueue_style( 'optionsframework', Options_Framework::root_url() . 'css/optionsframework.css', array(),  Options_Framework::VERSION );
 		wp_enqueue_style( 'wp-color-picker' );
 	}
 
@@ -195,7 +195,7 @@ class Options_Framework_Admin {
 	        return;
 
 		// Enqueue custom option panel JS
-		wp_enqueue_script( 'options-custom', plugin_dir_url( dirname(__FILE__) ) . 'js/options-custom.js', array( 'jquery','wp-color-picker' ), Options_Framework::VERSION );
+		wp_enqueue_script( 'options-custom', Options_Framework::root_url() . 'js/options-custom.js', array( 'jquery','wp-color-picker' ), Options_Framework::VERSION );
 
 		// Inline scripts from options-interface.php
 		add_action( 'admin_head', array( $this, 'of_admin_head' ) );

--- a/includes/class-options-framework.php
+++ b/includes/class-options-framework.php
@@ -119,4 +119,13 @@ class Options_Framework {
 		return $options;
 	}
 
+	/**
+	 * Returns root relative url of plugin
+	 */
+	function root_url() {
+        $site_root = str_replace( '/wp-content/themes', '', get_theme_root() );
+        $plugin_root = str_replace( $site_root, '', dirname(__FILE__) );
+        $plugin_root = str_replace( '/includes', '/', $plugin_root );
+        return $plugin_root;
+	}
 }

--- a/includes/class-options-media-uploader.php
+++ b/includes/class-options-media-uploader.php
@@ -113,7 +113,7 @@ class Options_Framework_Media_Uploader {
 		if ( function_exists( 'wp_enqueue_media' ) )
 			wp_enqueue_media();
 
-		wp_register_script( 'of-media-uploader', plugin_dir_url( dirname(__FILE__) ) .'js/media-uploader.js', array( 'jquery' ), Options_Framework::VERSION );
+		wp_register_script( 'of-media-uploader', Options_Framework::root_url() .'js/media-uploader.js', array( 'jquery' ), Options_Framework::VERSION );
 		wp_enqueue_script( 'of-media-uploader' );
 		wp_localize_script( 'of-media-uploader', 'optionsframework_l10n', array(
 			'upload' => __( 'Upload', 'options-framework' ),


### PR DESCRIPTION
We need to occasionally bake a plugin into a theme for our production environment needs. This change is intended to change the hard requiredment on the plugin being in wp-content/plugins.

Signed-off-by: Lee Hilton <lee.hilton@hipstercreative.com>