### PR TITLE
Use $menu['parent_slug'] in admin bar (if available)

### DIFF
--- a/includes/class-options-framework-admin.php
+++ b/includes/class-options-framework-admin.php
@@ -370,9 +370,21 @@ class Options_Framework_Admin {
 		global $wp_admin_bar;
 
 		if ( 'menu' == $menu['mode'] ) {
-			$href = admin_url( 'admin.php?page=' . $menu['menu_slug'] );
+
+			if ( isset( $menu['parent_slug'] ) ) {
+				$href = admin_url( $menu['parent_slug'] . '?page=' . $menu['menu_slug'] );
+			} else {
+				$href = admin_url( 'admin.php?page=' . $menu['menu_slug'] );
+			}
+
 		} else {
-			$href = admin_url( 'themes.php?page=' . $menu['menu_slug'] );
+
+			if ( isset( $menu['parent_slug'] ) ) {
+				$href = admin_url( $menu['parent_slug'] . '?page=' . $menu['menu_slug'] );
+			} else {
+				$href = admin_url( 'themes.php?page=' . $menu['menu_slug'] );
+			}
+
 		}
 
 		$args = array(


### PR DESCRIPTION
Hey Devin, Hope all is well. I'm using the optionsframework_menu filter to rename / move the Theme Options link from the appearance menu to the settings menu. Everything seems ok so far, except that the link in the admin bar wasn't respecting the parent_slug I was setting in the filter.
